### PR TITLE
Build limited ABI wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64] # [x86_64, x86, aarch64, armv7, s390x, ppc64le]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -46,12 +46,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64] # [x64, x86]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -69,12 +69,12 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        target: [universal2] # [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwop-fast"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,5 +9,5 @@ name = "qwop_fast"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.18.3"
+pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py38"] }
 rayon = "1.7"


### PR DESCRIPTION
It can be a little annoying for everyone who downloads the package to build the package from scratch. It is convenient for users if you also ship binary distributions. You can do this by enabling a CI (like Github Actions) and have it automatically build wheels for commonly used platforms.

The CI configuration that maturin automatically generated builds wheels for every possible environment, which would take a long time to build and would quickly eat into your free credits on whichever CI you choose to run it on, so I chose to modify CI.yml to only build Ubuntu x64, Windows x64, and Mac universal2 wheels, so it only takes 4 minutes to build the wheels. This compilation time is done on a server instead of every machine that downloads the package.

In addition, I enabled the "Limited ABI" feature that you can read about [here](https://pyo3.rs/v0.13.2/building_and_distribution#py_limited_apiabi3), which means that you can build a single abi3 wheel for all CPython versions instead of a different one for Python 3.8, 3.9, and 3.10.

You can download the build I made in GitHub Actions at the following link and verify that it works on your machine.

https://github.com/anivegesana/qwop-fast/actions/runs/5039251439